### PR TITLE
keycloak: Update oauth to support keycloak-oidc

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,7 +40,7 @@ oauth_skip_auth_routes: []
 #  - '/webhook'
 
 # Providers
-oauth_provider: 'github' # github, google, keycloak
+oauth_provider: 'github' # github, google, keycloak-oidc
 # Github
 oauth_github_org: 'status-im'
 oauth_github_teams: []
@@ -52,10 +52,8 @@ oauth_keycloak_realm: 'logos-co'
 oauth_keycloak_domain: '*'
 oauth_keycloak_groups: ['infra']
 oauth_keycloak_roles: []
-oauth_keycloak_login_url: '{{ oauth_keycloak_url }}/realms/{{ oauth_keycloak_realm }}/protocol/openid-connect/auth'
-oauth_keycloak_redeem_url: '{{ oauth_keycloak_url }}/realms/{{ oauth_keycloak_realm }}/protocol/openid-connect/token'
-oauth_keycloak_profile_url:  '{{ oauth_keycloak_url }}/realms/{{ oauth_keycloak_realm }}/protocol/openid-connect/userinfo'
-oauth_keycloak_validate_url:  '{{ oauth_keycloak_url }}/realms/{{ oauth_keycloak_realm }}/protocol/openid-connect/userinfo'
+oauth_keycloak_oidc_issuer_url: '{{ oauth_keycloak_url }}/realms/{{ oauth_keycloak_realm }}'
+oauth_keycloak_code_challenge_method: 'S256'
 
 # required auth options
 oauth_cookie_secret: ~
@@ -66,8 +64,8 @@ oauth_secret: ~
 oauth_logo_url: 'https://status.app/assets/favicon/default.png'
 oauth_provider_scopes:
   github: 'user:email read:org'
-  keycloak: 'openid'
-oauth_scope: '{{ oauth_provider_scopes.get("oauth_provider", "") }}'
+  keycloak-oidc: 'openid'
+oauth_scope: '{{ oauth_provider_scopes.get(oauth_provider, "") }}'
 
 # Consul
 oauth_consul_service_port: '{{ oauth_local_port }}'

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -1,5 +1,4 @@
 ---
-version: '3.7'
 services:
   oauth:
     container_name: '{{ oauth_cont_name }}'
@@ -25,13 +24,11 @@ services:
 {% endif %}
 {% elif oauth_provider == "google" %}
       --email-domain='{{ oauth_google_domain | mandatory }}'
-{% elif oauth_provider == "keycloak" %}
+{% elif oauth_provider == "keycloak-oidc" %}
       --scope='{{ oauth_scope }}'
-      --login-url='{{ oauth_keycloak_login_url }}'
-      --redeem-url='{{ oauth_keycloak_redeem_url }}'
-      --profile-url='{{ oauth_keycloak_profile_url }}'
-      --validate-url='{{ oauth_keycloak_validate_url }}'
+      --oidc-issuer-url='{{ oauth_keycloak_oidc_issuer_url | mandatory }}'
       --email-domain='{{ oauth_keycloak_domain | mandatory }}'
+      --code-challenge-method='{{ oauth_keycloak_code_challenge_method }}'
 {% for group in oauth_keycloak_groups %}
       --keycloak-group={{ group }}
 {% endfor %}


### PR DESCRIPTION
While resolving the referenced issue I've encountered that we are using oauth legacy provider for keycloak and decided to test it and update the role. Another update, which wasn't noticed until now, was selecting 'oauth_scope' by looking up at the 'oauth_provider_scopes' which always resulted in ' ' which is wrong.

Referenced issue: https://github.com/status-im/infra-misc/issues/285