### PR TITLE
compose: add oauth_extra_args for custom command line arguments

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,6 +67,7 @@ oauth_provider_scopes:
   github: 'user:email read:org'
   keycloak-oidc: 'openid'
 oauth_scope: '{{ oauth_provider_scopes.get(oauth_provider, "") }}'
+oauth_extra_args: []
 
 # Consul
 oauth_consul_service_port: '{{ oauth_local_port }}'

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -54,6 +54,9 @@ services:
 {% for route in oauth_skip_auth_routes %}
       --skip-auth-route={{ route }}
 {% endfor %}
+{% for arg in oauth_extra_args %}
+      {{ arg }}
+{% endfor %}
 {% if oauth_cont_networks %}
 
 networks:


### PR DESCRIPTION
Allows passing additional flags to oauth2-proxy via oauth_extra_args list. Useful for `--session-cookie-minimal=true` to fix cookie size issues with Keycloak tokens that exceed 4kb limit.